### PR TITLE
fix: old paths in deploy Dockerfile

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -17,9 +17,9 @@ COPY . .
 
 RUN git config --global http.sslVerify true &&\
     go install github.com/swaggo/swag/cmd/swag@v1.8.10 &&\
-    $GOPATH/bin/swag init -g cmd/main.go &&\
+    $GOPATH/bin/swag init -g cmd/service/main.go &&\
     go get -v ./... &&\
-    go build -o demo-echo ./cmd
+    go build -o demo-echo ./cmd/service
 
 FROM alpine
 


### PR DESCRIPTION
### 🎫 Ticket Reference
https://trello.com/c/0EZWu1a5/34-fix-dockerfile-for-deployment

### 📝 Changes
1. Fix outdated swag entrypoint path: `cmd/main.go` → `cmd/service/main.go`
2. Fix outdated build path: `./cmd` → `./cmd/service`

Verified the production image builds end-to-end and the binary is present at `/app/demo-echo`.